### PR TITLE
動かしていない飛び道具がポーズ時にUpdateActive=trueになる不具合の解消

### DIFF
--- a/GameSources/MainCamera.h
+++ b/GameSources/MainCamera.h
@@ -24,6 +24,10 @@ namespace basecross {
 		float m_RadY;                           // Y軸の回転角度
 		float m_RadXZ;                          // XZ平面の回転角度
 
+		float m_fixedDirY;						// Yボタン(Cキー)押したときの目標角度
+		float m_fixSpeed = 3.0f;				// 目標角度に向けて回す速度
+		bool m_isMovingToFixedDir = false;		// 目標角度に向けて移動中
+
 	public:
 		// コンストラクタ
 		CameraCollision(const shared_ptr<Stage>& StagePtr);
@@ -46,6 +50,9 @@ namespace basecross {
 
 		// 腕の長さを更新する
 		void UpdateArmLengh();
+
+		// カメラの向きをターゲットに合わせる
+		float FixCameraDirection(shared_ptr<GameObject>& Other, bool Input);
 
 		// 左右スティック変更のモードを取得する
 		bool GetLRBaseMode() const;

--- a/GameSources/Player.h
+++ b/GameSources/Player.h
@@ -370,6 +370,9 @@ namespace basecross {
 		//消去フラグ
 		bool m_lifeEnded;
 
+		//使用中フラグ
+		bool m_used = false;
+
 	public:
 		//構築と破棄
 
@@ -394,10 +397,18 @@ namespace basecross {
 			m_EfkPlay[0] = ObjectFactory::Create<EfkPlay>(m_EfkProj, GetComponent<Transform>()->GetPosition(), 0.0f);
 			m_EfkPlay[0]->SetRotation(Vec3(0, 1, 0), -face);
 			m_EfkPlay[0]->SetScale(Vec3(.8f));
+
+		}
+
+		//使用中か否か
+		bool GetUsed() {
+			return m_used;
 		}
 
 		//呼び出す
 		void Invoke(const Vec3 dist, const Vec3 angle, const float power) {
+			m_used = true;
+			GetComponent<TriggerSphere>()->SetUpdateActive(true);
 			SetUpdateActive(true);
 
 			m_stopped = false;
@@ -413,24 +424,6 @@ namespace basecross {
 			EffectStart();
 		}
 
-	};
-
-	//====================================================================
-	// class ChargePtcl
-	// チャージ中のパーティクル
-	//====================================================================
-
-	class ChargePtcl : public MultiParticle {
-	public:
-		ChargePtcl(const shared_ptr<Stage>& StagePtr) :
-			MultiParticle(StagePtr)
-		{
-		}
-		virtual ~ChargePtcl() {}
-
-		virtual void OnCreate() override;
-		virtual void OnUpdate() override;
-		void Emit(const Vec3& emitPos, const Vec3& randomEmitRange);
 	};
 
 	//====================================================================

--- a/GameSources/WinMain.cpp
+++ b/GameSources/WinMain.cpp
@@ -149,7 +149,7 @@ int MainLoop(HINSTANCE hInstance, HWND hWnd, bool isFullScreen, int iClientWidth
 			VK_PRIOR,VK_NEXT,VK_UP, VK_DOWN, VK_LEFT, VK_RIGHT,VK_SPACE,
 			VK_LBUTTON, VK_RBUTTON, VK_MBUTTON, VK_LCONTROL,VK_RETURN,VK_TAB,VK_BACK,
 			VK_SHIFT,VK_LMENU,
-			'W','A','S','D','X','B','Q'
+			'W','A','S','D','X','C','B','Q'
 		};
 		while (WM_QUIT != msg.message) {
 			if (!App::GetApp()->ResetInputState(hWnd, UseKeyVec)) {


### PR DESCRIPTION
メインカメラ改造　Cキー(Xボタン)を押すとプレイヤーの方向に向き直すFixCameraDirection関数